### PR TITLE
GCC's std does not like nullptr assignment to std::unique_ptr.

### DIFF
--- a/include/util_zip.h
+++ b/include/util_zip.h
@@ -30,7 +30,7 @@ public:
 	bool GetFileList(std::vector<std::string> &outFileList);
 private:
 	ZIPFile(std::unique_ptr<BaseZipFile> baseZipFile);
-	std::unique_ptr<BaseZipFile> m_baseZipFile = nullptr;
+    std::unique_ptr<BaseZipFile> m_baseZipFile;
 };
 
 #endif


### PR DESCRIPTION
Default constructor should prove sufficient.